### PR TITLE
Don't put the token in the query string

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,5 +1,5 @@
-let a = new URL(location.href);
-let token = a.searchParams.get("token");
+let params = new URLSearchParams(location.hash.substr(1));
+let token = params.get("token");
 if (token) {
 	new QRCode(document.getElementById("qrcode"), {
 		text: token,

--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
   let iframe = document.createElement("iframe");
   document.body.appendChild(iframe);
   let token = JSON.parse(iframe.contentWindow.localStorage.token);
-  window.open("https://cyan-2048.github.io/discordo/?token=" + encodeURIComponent(token), "_blank");
+  window.open("https://cyan-2048.github.io/discordo/#token=" + encodeURIComponent(token), "_blank");
   iframe.remove();
 })();
 </pre


### PR DESCRIPTION
The query string (`?token=XXX`) is sent to the server, while a hash is not. Merging this pull request would put it in the hash instead (`#token=XXX`) and thus keep it a bit more secret from whoever is hosting this site (in this case it's GitHub).